### PR TITLE
Implement body tracking capture pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# TENDOR-climbing
+
+This repository contains a Unity-based AR climbing project.
+
+## Body Tracking Capture
+
+The project now includes scripts for recording ARKit body tracking data while capturing video. Use **SessionRecorder** instead of **VideoRecorder** to save a `.body` file alongside the MP4.
+
+## Running Tests
+
+Open the project in the Unity Editor and use **Window > General > Test Runner** to run all Edit Mode and Play Mode tests.

--- a/TENDOR-climbing/Assets/Scripts/BodyTracker.cs
+++ b/TENDOR-climbing/Assets/Scripts/BodyTracker.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+
+public class BodyTracker : MonoBehaviour
+{
+    private ARHumanBody currentBody;
+    public ARHumanBody Current => currentBody;
+
+    private ARHumanBodyManager manager;
+
+    void OnEnable()
+    {
+        manager = GetComponent<ARHumanBodyManager>();
+        if (manager != null)
+            manager.humanBodiesChanged += OnBodiesChanged;
+    }
+
+    void OnDisable()
+    {
+        if (manager != null)
+            manager.humanBodiesChanged -= OnBodiesChanged;
+    }
+
+    void OnBodiesChanged(ARHumanBodiesChangedEventArgs args)
+    {
+        if (args.updated.Count > 0)
+            currentBody = args.updated[0];
+        else if (args.added.Count > 0)
+            currentBody = args.added[0];
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/BodyTracker.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/BodyTracker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8eb591d7115e1f15d54c39b7df30ca84

--- a/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs
+++ b/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class DebugOverlay : MonoBehaviour
+{
+    [SerializeField] private GameObject skeleton;
+    [SerializeField] private GameObject avatar;
+
+    public void SetVisible(bool visible)
+    {
+        if (skeleton) skeleton.SetActive(visible);
+        if (avatar) avatar.SetActive(visible);
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77bdebe1642ab22e6f5f188e5aefb568

--- a/TENDOR-climbing/Assets/Scripts/Globals.cs
+++ b/TENDOR-climbing/Assets/Scripts/Globals.cs
@@ -9,6 +9,10 @@ public class Globals : MonoBehaviour
     public static ARTrackedImageManager TrackedImageManager;
     public static ARRaycastManager RaycastManager;
     public static ARCameraManager CameraManager;
+    public static ARHumanBodyManager HumanBodyManager;
+    public static BodyTracker BodyTracker;
+    public static ARAnchorManager AnchorManager;
+    public static Transform ClimbWallAnchor;
     public static FileUploader FileUploader;
     public static GameObject UI;
 
@@ -21,6 +25,12 @@ public class Globals : MonoBehaviour
     [SerializeField]
     private ARCameraManager cameraManager;
     [SerializeField]
+    private ARHumanBodyManager humanBodyManager;
+    [SerializeField]
+    private BodyTracker bodyTracker;
+    [SerializeField]
+    private ARAnchorManager anchorManager;
+    [SerializeField]
     private FileUploader fileUploader;
     [SerializeField]
     private GameObject ui;
@@ -31,6 +41,9 @@ public class Globals : MonoBehaviour
         TrackedImageManager = trackedImageManager;
         RaycastManager = raycastManager;
         CameraManager = cameraManager;
+        HumanBodyManager = humanBodyManager;
+        BodyTracker = bodyTracker;
+        AnchorManager = anchorManager;
         FileUploader = fileUploader;
 
         UI = ui;

--- a/TENDOR-climbing/Assets/Scripts/HumanoidRetarget.cs
+++ b/TENDOR-climbing/Assets/Scripts/HumanoidRetarget.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+
+public class HumanoidRetarget : MonoBehaviour
+{
+    public float scale = 1f;
+
+    public void Retarget(ARHumanBody body, Animator animator)
+    {
+        if (body == null || animator == null)
+            return;
+
+        Transform hips = animator.GetBoneTransform(HumanBodyBones.Hips);
+        if (hips)
+        {
+            hips.position = body.transform.position;
+            hips.rotation = body.transform.rotation;
+        }
+    }
+
+    public void UpdateScale(Transform sourceHips, Transform sourceHead, Transform targetHips, Transform targetHead)
+    {
+        if (!sourceHips || !sourceHead || !targetHips || !targetHead)
+            return;
+        float src = Vector3.Distance(sourceHips.position, sourceHead.position);
+        float dst = Vector3.Distance(targetHips.position, targetHead.position);
+        if (dst > 0f)
+            scale = src / dst;
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/HumanoidRetarget.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/HumanoidRetarget.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 430e6539150618541747c6c36e0d952a

--- a/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs
+++ b/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlaybackManager : MonoBehaviour
+{
+    [SerializeField] private TextAsset bodyFile;
+    [SerializeField] private GameObject avatarPrefab;
+
+    private BodyFrame[] frames;
+    private int index;
+    private Transform avatar;
+
+    void Start()
+    {
+        if (bodyFile != null)
+        {
+            frames = JsonUtility.FromJson<BodyFrameCollection>(bodyFile.text).frames;
+        }
+        if (avatarPrefab != null)
+        {
+            avatar = Instantiate(avatarPrefab, Vector3.zero, Quaternion.identity).transform;
+        }
+        index = 0;
+    }
+
+    void Update()
+    {
+        if (frames == null || index >= frames.Length || avatar == null || Globals.ClimbWallAnchor == null)
+            return;
+
+        var frame = frames[index];
+        avatar.position = Globals.ClimbWallAnchor.TransformPoint(frame.position);
+        avatar.rotation = Globals.ClimbWallAnchor.rotation * frame.rotation;
+        index++;
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c70eb26ac7749db1ddb6c9c42dfa1725

--- a/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs
+++ b/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+
+[Serializable]
+public struct BodyFrame
+{
+    public float time;
+    public Vector3 position;
+    public Quaternion rotation;
+}
+
+[Serializable]
+public class BodyFrameCollection
+{
+    public BodyFrame[] frames;
+}
+
+public class SessionRecorder : VideoRecorder
+{
+    [SerializeField] private BodyTracker bodyTracker;
+
+    private List<BodyFrame> bodyFrames = new List<BodyFrame>();
+    private float startTime;
+
+    public override void StartRecording()
+    {
+        base.StartRecording();
+        startTime = Time.time;
+        bodyFrames.Clear();
+        if (!bodyTracker)
+            bodyTracker = Globals.BodyTracker;
+    }
+
+    public override void StopRecording()
+    {
+        base.StopRecording();
+        SaveFrames();
+    }
+
+    protected override void RecordFrame(ARCameraFrameEventArgs args)
+    {
+        base.RecordFrame(args);
+        if (bodyTracker && bodyTracker.Current)
+        {
+            Transform hips = bodyTracker.Current.transform;
+            Vector3 pos = hips.position;
+            Quaternion rot = hips.rotation;
+            if (Globals.ClimbWallAnchor)
+            {
+                pos = Globals.ClimbWallAnchor.InverseTransformPoint(pos);
+                rot = Quaternion.Inverse(Globals.ClimbWallAnchor.rotation) * rot;
+            }
+            BodyFrame frame = new BodyFrame
+            {
+                time = Time.time - startTime,
+                position = pos,
+                rotation = rot
+            };
+            bodyFrames.Add(frame);
+        }
+    }
+
+    private void SaveFrames()
+    {
+        BodyFrameCollection collection = new BodyFrameCollection { frames = bodyFrames.ToArray() };
+        string folder = Path.Combine(Application.persistentDataPath, "Captures");
+        if (!Directory.Exists(folder))
+            Directory.CreateDirectory(folder);
+        string path = Path.Combine(folder, DateTime.Now.ToString("yyyyMMdd_HHmmss") + ".body");
+        File.WriteAllText(path, JsonUtility.ToJson(collection));
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eae7366d1949c32351642ff8c979f5a5

--- a/TENDOR-climbing/Assets/Scripts/TrackingLogic.cs
+++ b/TENDOR-climbing/Assets/Scripts/TrackingLogic.cs
@@ -8,6 +8,7 @@ public class TrackingLogic : MonoBehaviour
 {
     private Content[] contents;
     private bool contentAttachedToPlane = false;
+    private bool anchorCreated = false;
 
     void OnEnable()
     {
@@ -46,6 +47,16 @@ public class TrackingLogic : MonoBehaviour
         var content = Array.Find(contents, content => content.name == trackedImage.referenceImage.name);
         if (content == null)
             return false;
+
+        if (!anchorCreated && Globals.AnchorManager != null)
+        {
+            var anchor = Globals.AnchorManager.AddAnchor(new Pose(trackedImage.transform.position, trackedImage.transform.rotation));
+            if (anchor != null)
+            {
+                Globals.ClimbWallAnchor = anchor.transform;
+                anchorCreated = true;
+            }
+        }
 
         // Initially attach content to the tracked image
         content.transform.parent = trackedImage.transform;

--- a/TENDOR-climbing/Assets/Scripts/VideoRecorder.cs
+++ b/TENDOR-climbing/Assets/Scripts/VideoRecorder.cs
@@ -81,7 +81,7 @@ public class VideoRecorder : MonoBehaviour
         yield return null;
     }
 
-    public void StartRecording()
+    public virtual void StartRecording()
     {
         tex = new Texture2D((int)Globals.CameraManager.currentConfiguration?.width, (int)Globals.CameraManager.currentConfiguration?.height, TextureFormat.RGBA32, false);
         image.texture = tex;
@@ -92,7 +92,7 @@ public class VideoRecorder : MonoBehaviour
         Globals.CameraManager.frameReceived += RecordFrame;
     }
 
-    public void StopRecording()
+    public virtual void StopRecording()
     {
         Globals.CameraManager.frameReceived -= RecordFrame;
         capture.StopCapture();
@@ -101,7 +101,7 @@ public class VideoRecorder : MonoBehaviour
         //Globals.FileUploader.StartUpload(bytes);
     }
 
-    private void RecordFrame(ARCameraFrameEventArgs args)
+    protected virtual void RecordFrame(ARCameraFrameEventArgs args)
     {
         if (!Globals.CameraManager.TryAcquireLatestCpuImage(out cpuImage))
             return;


### PR DESCRIPTION
## Summary
- store ARKit body data with new **BodyTracker** component
- update `Globals` to expose body tracking and anchor managers
- add **SessionRecorder** to save hip poses alongside video
- create **PlaybackManager** to replay DeepMotion avatar
- add debug overlay and retarget helper scripts
- document body tracking capture in README

## Testing
- `git status --short`