### PR TITLE
Add body tracking recording and playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# TENDOR-climbing
+
+This repository contains a Unity-based AR climbing project.
+
+## Recording & Playback
+
+The project now includes a **SessionRecorder** that captures both RGB video and
+ARKit body tracking data. Each recording creates an MP4 and a matching `.body`
+file under `Application.persistentDataPath/Captures/`.
+
+Use **ModeSwitcher** to toggle between recording and playback. When switching
+to playback, the latest session file is loaded and a humanoid avatar is spawned
+via `PlaybackManager`.
+
+## Running Tests
+
+Open the project in the Unity Editor and use **Window > General > Test Runner** to run all Edit Mode and Play Mode tests.

--- a/TENDOR-climbing/Assets/Scripts/BodyTracker.cs
+++ b/TENDOR-climbing/Assets/Scripts/BodyTracker.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+using UnityEngine.XR.ARSubsystems;
+
+public class BodyTracker : MonoBehaviour
+{
+    public ARHumanBody Current { get; private set; }
+
+    void OnEnable()
+    {
+        var manager = Globals.BodyManager;
+        if (manager != null)
+            manager.humanBodiesChanged += OnBodiesChanged;
+    }
+
+    void OnDisable()
+    {
+        var manager = Globals.BodyManager;
+        if (manager != null)
+            manager.humanBodiesChanged -= OnBodiesChanged;
+    }
+
+    void OnBodiesChanged(ARHumanBodiesChangedEventArgs args)
+    {
+        if (args.added.Count > 0)
+            Current = args.added[0];
+        else if (args.updated.Count > 0)
+            Current = args.updated[0];
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/BodyTracker.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/BodyTracker.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb0058dadd446b418ec04a26a725d92
+guid: 78156d4c50fe4c938499f298c008db98
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs
+++ b/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+
+public class DebugOverlay : MonoBehaviour
+{
+    [SerializeField] private GameObject skeletonGO;
+
+    void Update()
+    {
+        if (Globals.BodyTracker?.Current == null) return;
+        skeletonGO.SetActive(true);
+        skeletonGO.transform.SetPositionAndRotation(
+            Globals.BodyTracker.Current.transform.position,
+            Globals.BodyTracker.Current.transform.rotation);
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/DebugOverlay.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb0058dadd446b418ec04a26a725d92
+guid: d24ef6bea92242f3bfce25f9a05befed
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TENDOR-climbing/Assets/Scripts/Globals.cs
+++ b/TENDOR-climbing/Assets/Scripts/Globals.cs
@@ -9,6 +9,9 @@ public class Globals : MonoBehaviour
     public static ARTrackedImageManager TrackedImageManager;
     public static ARRaycastManager RaycastManager;
     public static ARCameraManager CameraManager;
+    public static ARHumanBodyManager BodyManager;
+    public static BodyTracker BodyTracker;
+    public static Transform ClimbWallAnchor;
     public static FileUploader FileUploader;
     public static GameObject UI;
 
@@ -21,6 +24,12 @@ public class Globals : MonoBehaviour
     [SerializeField]
     private ARCameraManager cameraManager;
     [SerializeField]
+    private ARHumanBodyManager bodyManager;
+    [SerializeField]
+    private BodyTracker bodyTracker;
+    [SerializeField]
+    private Transform climbWallAnchor;
+    [SerializeField]
     private FileUploader fileUploader;
     [SerializeField]
     private GameObject ui;
@@ -32,6 +41,9 @@ public class Globals : MonoBehaviour
         RaycastManager = raycastManager;
         CameraManager = cameraManager;
         FileUploader = fileUploader;
+        BodyManager = bodyManager;
+        BodyTracker = bodyTracker;
+        ClimbWallAnchor = climbWallAnchor;
 
         UI = ui;
     }

--- a/TENDOR-climbing/Assets/Scripts/ModeSwitcher.cs
+++ b/TENDOR-climbing/Assets/Scripts/ModeSwitcher.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+public class ModeSwitcher : MonoBehaviour
+{
+    [SerializeField] private SessionRecorder recorder;
+    [SerializeField] private PlaybackManager playback;
+    [SerializeField] private GameObject recordUI;
+    [SerializeField] private GameObject playbackUI;
+
+    bool recording = false;
+
+    public void ToggleMode()
+    {
+        if (!recording)
+        {
+            recorder.StartRecording();
+            recordUI.SetActive(true);
+            playbackUI.SetActive(false);
+        }
+        else
+        {
+            recorder.StopRecording();
+            recordUI.SetActive(false);
+            playbackUI.SetActive(true);
+        }
+        recording = !recording;
+    }
+
+    public void PlayLatest()
+    {
+        var folder = Application.persistentDataPath + "/Captures";
+        var files = System.IO.Directory.GetFiles(folder, "*.body");
+        if (files.Length > 0)
+            playback.Load(files[files.Length - 1]);
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/ModeSwitcher.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/ModeSwitcher.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb0058dadd446b418ec04a26a725d92
+guid: 0b6080d9446342caa30f48c173822d86
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs
+++ b/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+public class PlaybackManager : MonoBehaviour
+{
+    [SerializeField] private GameObject avatarPrefab;
+    GameObject avatarInstance;
+    List<Pose> poses = new List<Pose>();
+    int index;
+
+    public void Load(string path)
+    {
+        poses.Clear();
+        foreach (var line in File.ReadAllLines(path))
+        {
+            var parts = line.Split(',');
+            if (parts.Length < 8) continue;
+            var pos = new Vector3(
+                float.Parse(parts[1]),
+                float.Parse(parts[2]),
+                float.Parse(parts[3]));
+            var rot = new Quaternion(
+                float.Parse(parts[4]),
+                float.Parse(parts[5]),
+                float.Parse(parts[6]),
+                float.Parse(parts[7]));
+            poses.Add(new Pose(pos, rot));
+        }
+        index = 0;
+        if (avatarInstance)
+            Destroy(avatarInstance);
+        avatarInstance = Instantiate(avatarPrefab, Vector3.zero, Quaternion.identity);
+    }
+
+    void Update()
+    {
+        if (avatarInstance == null || Globals.ClimbWallAnchor == null) return;
+        if (index >= poses.Count) return;
+
+        var local = poses[index++];
+        avatarInstance.transform.position = Globals.ClimbWallAnchor.TransformPoint(local.position);
+        avatarInstance.transform.rotation = Globals.ClimbWallAnchor.rotation * local.rotation;
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/PlaybackManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb0058dadd446b418ec04a26a725d92
+guid: 38851ef3e3d94c258d0bd80cf3c3a0b1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs
+++ b/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+using UnityEngine.XR.ARSubsystems;
+
+public class SessionRecorder : VideoRecorder
+{
+    StreamWriter writer;
+
+    public override void StartRecording()
+    {
+        base.StartRecording();
+        var folder = Path.Combine(Application.persistentDataPath, "Captures");
+        Directory.CreateDirectory(folder);
+        var name = System.DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        var path = Path.Combine(folder, name + ".body");
+        writer = new StreamWriter(path);
+    }
+
+    public override void StopRecording()
+    {
+        base.StopRecording();
+        writer?.Close();
+    }
+
+    protected override void RecordFrame(ARCameraFrameEventArgs args)
+    {
+        base.RecordFrame(args);
+        if (writer == null) return;
+
+        var body = Globals.BodyTracker?.Current;
+        if (body == null || Globals.ClimbWallAnchor == null)
+            return;
+
+        var hips = body.joints[(int)XRHumanBodyJointType.Spine];
+        if (!hips.tracked)
+            return;
+        var worldPos = hips.anchorPose.position;
+        var worldRot = hips.anchorPose.rotation;
+        var localPos = Globals.ClimbWallAnchor.InverseTransformPoint(worldPos);
+        var localRot = Quaternion.Inverse(Globals.ClimbWallAnchor.rotation) * worldRot;
+        writer.WriteLine($"{Time.time:F4},{localPos.x:F4},{localPos.y:F4},{localPos.z:F4},{localRot.x:F4},{localRot.y:F4},{localRot.z:F4},{localRot.w:F4}");
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/SessionRecorder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: adb0058dadd446b418ec04a26a725d92
+guid: f603083c3f33450495c14c997d40f7cc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TENDOR-climbing/Assets/Scripts/TrackingLogic.cs
+++ b/TENDOR-climbing/Assets/Scripts/TrackingLogic.cs
@@ -8,6 +8,7 @@ public class TrackingLogic : MonoBehaviour
 {
     private Content[] contents;
     private bool contentAttachedToPlane = false;
+    private bool anchorCreated = false;
 
     void OnEnable()
     {
@@ -46,6 +47,15 @@ public class TrackingLogic : MonoBehaviour
         var content = Array.Find(contents, content => content.name == trackedImage.referenceImage.name);
         if (content == null)
             return false;
+
+        if (!anchorCreated && trackedImage.trackingState == TrackingState.Tracking)
+        {
+            var anchor = new GameObject("ClimbWallAnchor").transform;
+            anchor.position = trackedImage.transform.position;
+            anchor.rotation = trackedImage.transform.rotation;
+            Globals.ClimbWallAnchor = anchor;
+            anchorCreated = true;
+        }
 
         // Initially attach content to the tracked image
         content.transform.parent = trackedImage.transform;

--- a/TENDOR-climbing/Assets/Scripts/VideoRecorder.cs
+++ b/TENDOR-climbing/Assets/Scripts/VideoRecorder.cs
@@ -81,7 +81,7 @@ public class VideoRecorder : MonoBehaviour
         yield return null;
     }
 
-    public void StartRecording()
+    public virtual void StartRecording()
     {
         tex = new Texture2D((int)Globals.CameraManager.currentConfiguration?.width, (int)Globals.CameraManager.currentConfiguration?.height, TextureFormat.RGBA32, false);
         image.texture = tex;
@@ -92,7 +92,7 @@ public class VideoRecorder : MonoBehaviour
         Globals.CameraManager.frameReceived += RecordFrame;
     }
 
-    public void StopRecording()
+    public virtual void StopRecording()
     {
         Globals.CameraManager.frameReceived -= RecordFrame;
         capture.StopCapture();
@@ -101,7 +101,7 @@ public class VideoRecorder : MonoBehaviour
         //Globals.FileUploader.StartUpload(bytes);
     }
 
-    private void RecordFrame(ARCameraFrameEventArgs args)
+    protected virtual void RecordFrame(ARCameraFrameEventArgs args)
     {
         if (!Globals.CameraManager.TryAcquireLatestCpuImage(out cpuImage))
             return;


### PR DESCRIPTION
## Summary
- extend VideoRecorder to allow subclasses
- add BodyTracker to cache the latest ARHumanBody
- expose body tracking references via Globals
- anchor content on first tracked image and store for recording
- create SessionRecorder that writes hip poses relative to anchor
- add PlaybackManager to load recorded data and spawn an avatar
- add DebugOverlay and ModeSwitcher for toggling recording/playback
- document the new workflow in README

## Testing
- `git status --short`