### PR TITLE
Improve session recording checks and playback

### DIFF
--- a/TENDOR-climbing/Assets/Scripts/LatestPlaybackManager.cs
+++ b/TENDOR-climbing/Assets/Scripts/LatestPlaybackManager.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+public class LatestPlaybackManager : MonoBehaviour
+{
+    [SerializeField] private GameObject avatarPrefab;
+
+    private BodyFrame[] frames;
+    private int index;
+    private Transform avatar;
+
+    void Start()
+    {
+        string folder = Path.Combine(Application.persistentDataPath, "Captures");
+        if (Directory.Exists(folder))
+        {
+            var files = Directory.GetFiles(folder, "*.body");
+            if (files.Length > 0)
+            {
+                Array.Sort(files);
+                string last = files[files.Length - 1];
+                string json = File.ReadAllText(last);
+                frames = JsonUtility.FromJson<BodyFrameCollection>(json).frames;
+            }
+        }
+
+        if (avatarPrefab != null)
+        {
+            avatar = Instantiate(avatarPrefab, Vector3.zero, Quaternion.identity).transform;
+        }
+        index = 0;
+    }
+
+    void Update()
+    {
+        if (frames == null || index >= frames.Length || avatar == null || Globals.ClimbWallAnchor == null)
+            return;
+
+        var frame = frames[index];
+        avatar.position = Globals.ClimbWallAnchor.TransformPoint(frame.position);
+        avatar.rotation = Globals.ClimbWallAnchor.rotation * frame.rotation;
+        index++;
+    }
+}

--- a/TENDOR-climbing/Assets/Scripts/LatestPlaybackManager.cs.meta
+++ b/TENDOR-climbing/Assets/Scripts/LatestPlaybackManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ea0af6ecf4e497c8c5cec3793b63d78


### PR DESCRIPTION
## Summary
- save body frames relative to image target and require anchor before recording
- log when image target is detected during a recording session
- add loader for playing back the most recent recording

## Testing
- `git status --short`